### PR TITLE
Fix RTD build failures

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,11 +11,6 @@ build:
   tools:
     python: "3.11"
 
-# Build PDF & ePub
-formats:
-  - epub
-  - pdf
-
 # Where the Sphinx conf.py file is located
 sphinx:
    configuration: docs/source/conf.py


### PR DESCRIPTION
RTD builds were failing because they were not able to generate the pdf/epub for svg files, this is not required anyway so removing this temporarily.